### PR TITLE
Switzer homework1 include schema names

### DIFF
--- a/submission/query_1.sql
+++ b/submission/query_1.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE TABLE billyswitzer.actors
+(
+  actor VARCHAR,
+  actor_id VARCHAR,
+  films ARRAY(ROW(film VARCHAR, votes INTEGER, rating DOUBLE, film_id VARCHAR)),
+  quality_class VARCHAR,
+  is_active BOOLEAN,
+  current_year INTEGER 
+)
+WITH
+(
+  FORMAT = 'PARQUET',
+  PARTITIONING = ARRAY['current_year']
+)

--- a/submission/query_2.sql
+++ b/submission/query_2.sql
@@ -1,0 +1,45 @@
+--Ideally would parameterize the current year rather than hardcoding. Airflow is a potential solution for this.
+--Also we should add a DELETE statement on existing records for the provided current_year so that the process is idempotent.
+INSERT INTO billyswitzer.actors
+WITH last_year AS (
+  SELECT actor,
+    actor_id,
+    films,
+    quality_class,
+    is_active,
+    current_year
+  FROM billyswitzer.actors
+  where current_year = 1918
+), current_year_temp AS (
+--Compute average_rating first, then use the result in the current_year CTE to calculate quality_class
+  SELECT actor,
+    actor_id,
+    year,
+    ARRAY_AGG(ROW(film, votes, rating, film_id)) AS films,
+    AVG(rating) AS average_rating
+  FROM bootcamp.actor_films
+  WHERE year = 1919
+  GROUP BY actor,
+    actor_id,
+    year
+), current_year AS (
+  SELECT actor,
+    actor_id,
+    year,
+    films,
+    CASE WHEN average_rating > 8 THEN 'star'
+      WHEN average_rating > 7 THEN 'good'
+      WHEN average_rating > 6 THEN 'average'
+      ELSE 'bad' END AS quality_class
+  FROM current_year_temp
+)
+SELECT COALESCE(ly.actor, cy.actor) as actor,
+  COALESCE(ly.actor_id, cy.actor_id) as actor_id,
+  CASE WHEN ly.films IS NOT NULL AND cy.films IS NOT NULL THEN cy.films || ly.films
+    WHEN ly.films IS NULL THEN cy.films
+    WHEN cy.films IS NULL THEN ly.films END AS films,
+  COALESCE(cy.quality_class, ly.quality_class) as quality_class,
+  cy.actor_id IS NOT NULL as is_active,
+  COALESCE(cy.year, ly.current_year + 1) as current_year
+FROM last_year ly
+  FULL OUTER JOIN current_year cy on ly.actor_id = cy.actor_id

--- a/submission/query_3.sql
+++ b/submission/query_3.sql
@@ -1,4 +1,4 @@
-CREATE TABLE billyswitzer.actors_history_scd
+CREATE OR REPLACE TABLE billyswitzer.actors_history_scd
 (
   actor VARCHAR,
   actor_id VARCHAR,

--- a/submission/query_3.sql
+++ b/submission/query_3.sql
@@ -1,0 +1,15 @@
+CREATE TABLE billyswitzer.actors_history_scd
+(
+  actor VARCHAR,
+  actor_id VARCHAR,
+  quality_class VARCHAR,  
+  is_active BOOLEAN,
+  start_date DATE,
+  end_date DATE,
+  current_year INTEGER
+)
+WITH 
+(
+  FORMAT = 'PARQUET',
+  PARTITIONING = ARRAY['current_year']
+)

--- a/submission/query_4.sql
+++ b/submission/query_4.sql
@@ -1,0 +1,27 @@
+INSERT INTO billyswitzer.actors_history_scd
+WITH lagged AS (SELECT actor,
+	  actor_id,
+	  quality_class,
+	  is_active,
+	  current_year,
+	  LAG(is_active,1) OVER (PARTITION BY actor, actor_id ORDER BY current_year) AS is_active_last_year,
+	  LAG(quality_class,1) OVER (PARTITION BY actor, actor_id ORDER BY current_year) AS quality_class_last_year
+	FROM billyswitzer.actors
+), streaked AS (SELECT *,
+	  --A change either to is_active or quality_class designates a new streak
+	  SUM(CASE WHEN is_active <> COALESCE(is_active_last_year,false) OR quality_class <> COALESCE(quality_class_last_year,'') THEN 1 ELSE 0 END) OVER (PARTITION BY actor, actor_id ORDER BY current_year) AS streak_identifier
+	FROM lagged
+), cy AS (SELECT MAX(current_year) as max_current_year
+	FROM billyswitzer.actors)
+SELECT actor,
+  actor_id,
+  MAX(quality_class) AS quality_class,
+  MAX(is_active) AS is_active,
+  CAST(CAST(MIN(current_year) AS VARCHAR) || '-01-01' AS DATE) AS start_date,
+  CAST(CAST(MAX(current_year) AS VARCHAR) || '-12-31' AS DATE) AS end_date,
+  MAX(cy.max_current_year) AS current_year    --Dynamically set the most recent partition in the source dataset as the current_year
+FROM streaked
+	CROSS JOIN cy
+GROUP BY actor,
+  actor_id,
+  streak_identifier

--- a/submission/query_5.sql
+++ b/submission/query_5.sql
@@ -1,0 +1,57 @@
+--Ideally we would parameterize the current_year and would delete all records for the current_year prior to running so that the process is idempotent
+--Once data quality checks have been run successfully, previous partitions of actors_history_scd can be deleted
+INSERT INTO billyswitzer.actors_history_scd
+WITH last_year_scd AS 
+(
+	SELECT *
+	FROM billyswitzer.actors_history_scd
+	WHERE current_year = 1919
+), current_year_table AS 
+(
+	SELECT *
+	FROM billyswitzer.actors
+	WHERE current_year = 1920
+), current_year_value AS
+(
+  SELECT MAX(current_year) AS max_current_year
+  FROM current_year_table
+), combined AS 
+(
+	SELECT COALESCE(lys.actor,cyt.actor) AS actor,
+	  COALESCE(lys.actor_id, cyt.actor_id) AS actor_id,
+	  --Check quality_class and is_active to detect a change. A NULL for did_change indicates a previous year which will be carried forward with no changes.
+	  CASE WHEN lys.quality_class = cyt.quality_class AND lys.is_active = cyt.is_active THEN 0
+	    WHEN lys.quality_class <> cyt.quality_class OR lys.is_active <> cyt.is_active THEN 1 END AS did_change,
+	  cyv.max_current_year AS current_year,
+	  COALESCE(lys.start_date, CAST(CAST(cyt.current_year AS VARCHAR) || '-01-01' AS DATE)) AS start_date,
+	  COALESCE(lys.end_date, CAST(CAST(cyt.current_year AS VARCHAR) || '-12-31' AS DATE)) AS end_date,
+	  lys.quality_class AS last_quality_class,
+	  cyt.quality_class AS current_quality_class,
+	  lys.is_active AS last_is_active,
+	  cyt.is_active AS current_is_active
+	FROM last_year_scd lys
+		FULL OUTER JOIN current_year_table cyt ON lys.actor_id = cyt.actor_id
+			AND lys.end_date + INTERVAL '1' YEAR = CAST(CAST(cyt.current_year AS VARCHAR) || '-12-31' AS DATE)
+		CROSS JOIN current_year_value cyv
+), changes AS 
+(
+  SELECT actor,
+    actor_id,
+    current_year,
+	--when did_change = 0 - take the values from last year's row, but update the end_date to the current_year
+	--when did_change = 1 - Pull last year's data forward and add a new row for the current year
+	--when did_change IS NULL - This is a previous year. Add the row to an array to carry it forward
+    CASE WHEN did_change = 0 THEN ARRAY[CAST(ROW(last_quality_class, last_is_active, start_date, CAST(CAST(current_year AS VARCHAR) || '-12-31' AS DATE)) AS ROW(quality_class VARCHAR, is_active BOOLEAN, start_date DATE, end_date DATE))]
+      WHEN did_change = 1 THEN ARRAY[CAST(ROW(last_quality_class, last_is_active, start_date, end_date) AS ROW(quality_class VARCHAR, is_active BOOLEAN, start_date DATE, end_date DATE)), CAST(ROW(current_quality_class, current_is_active, CAST(CAST(current_year AS VARCHAR) || '-01-01' AS DATE), CAST(CAST(current_year AS VARCHAR) || '-12-31' AS DATE)) AS ROW(quality_class VARCHAR, is_active BOOLEAN, start_date DATE, end_date DATE))]
+      WHEN did_change IS NULL THEN ARRAY[CAST(ROW(COALESCE(last_quality_class, current_quality_class), COALESCE(last_is_active, current_is_active), start_date, end_date) AS ROW(quality_class VARCHAR, is_active BOOLEAN, start_date DATE, end_date DATE))] END AS change_array
+  FROM combined
+)
+SELECT c.actor,
+  c.actor_id,
+  arr.quality_class,
+  arr.is_active,
+  arr.start_date,
+  arr.end_date,
+  c.current_year
+FROM changes c
+  CROSS JOIN UNNEST(c.change_array) arr


### PR DESCRIPTION
The attached queries are DDL and DML statements for a cumulative table named actors based on the bootcamp.actor_films table, and a type-2 SCD actors_history_scd table based on the actors table.

The actors table is defined as follows:

- `actor`: Actor name
- `actor_id`: Actor's ID
- `films`: An array of `struct` with the following fields:
  - `film`: The name of the film.
  - `votes`: The number of votes the film received.
  - `rating`: The rating of the film.
  - `film_id`: A unique identifier for each film.
- `quality_class`: A categorical bucketing of the average rating of the movies for this actor in their most recent year:
  - `star`: Average rating > 8.
  - `good`: Average rating > 7 and ≤ 8.
  - `average`: Average rating > 6 and ≤ 7.
  - `bad`: Average rating ≤ 6.
- `is_active`: A BOOLEAN field that indicates whether an actor is currently active in the film industry (i.e., making films this year).
- `current_year`: The year this row represents for the actor

The actors_history_scd table tracks changes to the is_active and quality_class fields from the actors table by date.

Updated files are:

query_1 - DDL statement for actors table
query_2 - DML statement to populate one year of the actors table, with films as a cumulative array
query_3 - DDL statement for SCD type 2 table - actors_history_scd
query_4 - Single query to backfill the actors_history_scd from the actors table
query_5 - DML query for an incremental load of the actors_history_scd table from the actors table - loading only the newest year